### PR TITLE
Change Esprima with Cherow

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const esprima = require("esprima");
+const cherow = require("cherow");
 
 /**
  * Instantiate a class with arguments
@@ -69,7 +69,7 @@ exports.getAllPropertyNames = function getAllPropertyNames(obj) {
  *      Array of names of the dependency
  */
 exports.dependencyNames = function dependencyNames(fn) {
-    let ast = esprima.parse("("+fn.toString()+")");
+    let ast = cherow.parseScript("("+fn.toString()+")");
     
     let expression = ast.body[0].expression;
     

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "bluebird-co": "^2.2.0",
+    "cherow": "^0.11.9",
     "colors": "^1.1.2",
     "dateformat": "^1.0.12",
-    "esprima": "^2.7.2",
     "is-class": "0.0.4",
     "lodash": "^4.1.0",
     "to-snake-case": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "bluebird-co": "^2.2.0",
-    "cherow": "^0.11.9",
+    "cherow": "^1.2.3",
     "colors": "^1.1.2",
     "dateformat": "^1.0.12",
     "is-class": "0.0.4",


### PR DESCRIPTION
Cherow is compatible with ES2017, so users can code in ES2017 (e.g. ES2017 async/await) with Merapi