### PR TITLE
Add elastic APM support

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const Injector = require("./lib/injector");
 const Component = require("./lib/component");
 const Logger = require("./lib/logger");
 const utils = require("./lib/utils");
+const apm = require("./lib/apm");
 
 function merapi(options) {
     return new Container(options);
@@ -199,6 +200,7 @@ class Container extends Component.mixin(AsyncEmitter) {
     }
 
     *start() {
+        apm(this.config);
         yield this.emit("beforeStart", this);
         let main = this.config("main");
 

--- a/lib/apm.js
+++ b/lib/apm.js
@@ -8,7 +8,7 @@ function Start(config) {
             serverUrl: config.data.apm.server,
             active: true,
             asyncHooks: true,
-            logLevel: 'info',
+            logLevel: "info",
             captureSpanStackTraces: true,
             captureExceptions: true,
         });

--- a/lib/apm.js
+++ b/lib/apm.js
@@ -4,7 +4,12 @@ function Start(config) {
     if (config.apm !== undefined) {
         require("elastic-apm-node").start({
             serviceName: config.name,
-            serverUrl: config.apm.server
+            serverUrl: config.apm.server,
+            active: true,
+            asyncHooks: true,
+            logLevel: "debug",
+            captureSpanStackTraces: true,
+            captureExceptions: true,
         });
     }
 }

--- a/lib/apm.js
+++ b/lib/apm.js
@@ -1,0 +1,19 @@
+"use strict"
+
+function Start(config){
+    var a = require('elastic-apm-node').start({
+        // Override service name from package.json
+        // Allowed characters: a-z, A-Z, 0-9, -, _, and space
+        //serviceName: config.name,
+        serviceName: "test-apm-from-merapi",
+        
+        // Use if APM Server requires a token
+        secretToken: '',
+      
+        // Set custom APM Server URL (default: http://localhost:8200)
+        serverUrl: 'http://35.187.250.255:8200'
+       // serverUrl: config.apm.url
+      })
+}
+
+module.exports = Start

--- a/lib/apm.js
+++ b/lib/apm.js
@@ -1,10 +1,11 @@
 "use strict";
 
 function Start(config) {
-    if (config.apm !== undefined) {
+    config.resolve();
+    if (config.data.apm !== undefined) {
         require("elastic-apm-node").start({
-            serviceName: config.name,
-            serverUrl: config.apm.server,
+            serviceName: config.data.name,
+            serverUrl: config.data.apm.server,
             active: true,
             asyncHooks: true,
             logLevel: "debug",

--- a/lib/apm.js
+++ b/lib/apm.js
@@ -8,7 +8,7 @@ function Start(config) {
             serverUrl: config.data.apm.server,
             active: true,
             asyncHooks: true,
-            logLevel: 'Info',
+            logLevel: 'info',
             captureSpanStackTraces: true,
             captureExceptions: true,
         });

--- a/lib/apm.js
+++ b/lib/apm.js
@@ -1,19 +1,21 @@
 "use strict"
 
 function Start(config){
+    if(config.apm !== undefined){
     var a = require('elastic-apm-node').start({
         // Override service name from package.json
         // Allowed characters: a-z, A-Z, 0-9, -, _, and space
         //serviceName: config.name,
-        serviceName: "test-apm-from-merapi",
+        serviceName: config.name,
         
         // Use if APM Server requires a token
         secretToken: '',
       
         // Set custom APM Server URL (default: http://localhost:8200)
-        serverUrl: 'http://35.187.250.255:8200'
+        serverUrl: config.apm.server
        // serverUrl: config.apm.url
       })
+    }
 }
 
 module.exports = Start

--- a/lib/apm.js
+++ b/lib/apm.js
@@ -1,12 +1,12 @@
 "use strict";
 
 function Start(config) {
-  if (config.apm !== undefined) {
-    require("elastic-apm-node").start({
-      serviceName: config.name,
-      serverUrl: config.apm.server
-    });
-  }
+    if (config.apm !== undefined) {
+        require("elastic-apm-node").start({
+            serviceName: config.name,
+            serverUrl: config.apm.server
+        });
+    }
 }
 
 module.exports = Start;

--- a/lib/apm.js
+++ b/lib/apm.js
@@ -1,21 +1,12 @@
-"use strict"
+"use strict";
 
-function Start(config){
-    if(config.apm !== undefined){
-    var a = require('elastic-apm-node').start({
-        // Override service name from package.json
-        // Allowed characters: a-z, A-Z, 0-9, -, _, and space
-        //serviceName: config.name,
-        serviceName: config.name,
-        
-        // Use if APM Server requires a token
-        secretToken: '',
-      
-        // Set custom APM Server URL (default: http://localhost:8200)
-        serverUrl: config.apm.server
-       // serverUrl: config.apm.url
-      })
-    }
+function Start(config) {
+  if (config.apm !== undefined) {
+    require("elastic-apm-node").start({
+      serviceName: config.name,
+      serverUrl: config.apm.server
+    });
+  }
 }
 
-module.exports = Start
+module.exports = Start;

--- a/lib/apm.js
+++ b/lib/apm.js
@@ -2,13 +2,13 @@
 
 function Start(config) {
     config.resolve();
-    if (config.data.apm !== undefined) {
+    if (config.data.apm && typeof config.data.apm === "object") {
         require("elastic-apm-node").start({
             serviceName: config.data.name,
             serverUrl: config.data.apm.server,
             active: true,
             asyncHooks: true,
-            logLevel: "debug",
+            logLevel: 'Info',
             captureSpanStackTraces: true,
             captureExceptions: true,
         });


### PR DESCRIPTION
## Overview
Kata Platform need to have distribution tracing tools to direct pin-point the error ,therefore we choose Elastic APM.  to fulfill the purpose we need to create interface in merapi so that can communicate efficiently with APM Server 

## How to solve
* Add apm function and run it on first layer before plugins, components and express up and running

## How to test
* load this branch into merapi-skeleton-ts 
* add new config on service.yml as follow:
`apm:
    server: {APMServerURL}`
