### PR TITLE
Fix: Regex Filter Number

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -46,7 +46,7 @@ class Config {
         if (!path) return this.data;
         let val, data = this.data;
         path = path.replace(/^\[/g, "").replace(/\[/g, ".").replace(/\]/g, "");
-        let parts = path.split(".").map(o => /^\d+$/.test(o) ? parseInt(o) : o);
+        let parts = path.split(".").map(o => /^(0|[1-9][0-9]*)$/.test(o) ? parseInt(o) : o);
         for (let i = 0; i < parts.length; i++) {
             val = data && data[parts[i]];
             if (val === undefined) {
@@ -87,7 +87,7 @@ class Config {
             return data;
         } else {
             let parts = path.split(".").map(function(o) {
-                if (/^\d+$/.test(o)) return parseInt(o);
+                if (/^(0|[1-9][0-9]*)$/.test(o)) return parseInt(o);
                 return o;
             });
             let current = parts.pop();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "merapi",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "merapi",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Javascript Framework for Microservices",
   "main": "./index.js",
   "types": "./index.d.ts",


### PR DESCRIPTION
# Kata Pull Request Template

Related: ?

## Overview

When user create cms element with id `01` bot can't get the value. Because in `merapi` when read config the key config will validate first. Is the key is number then the key will parse to integer. So the key will replace to `1` it make cms element not found.

## How to solve the problem

Update Regex to `/^(0|[1-9][0-9]*)$/`